### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/ShapeFileTest.php
+++ b/tests/ShapeFileTest.php
@@ -24,8 +24,9 @@ namespace ShapeFileTest;
 
 use PhpMyAdmin\ShapeFile\ShapeFile;
 use PhpMyAdmin\ShapeFile\ShapeRecord;
+use PHPUnit\Framework\TestCase;
 
-class ShapeFileTest extends \PHPUnit_Framework_TestCase
+class ShapeFileTest extends TestCase
 {
     /**
      * Tests loading of a file.

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -22,8 +22,9 @@
 namespace UtilTest;
 
 use PhpMyAdmin\ShapeFile\Util;
+use PHPUnit\Framework\TestCase;
 
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     /**
      * Test data loading.


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).