### PR TITLE
Bump minimum version to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,9 @@ language: php
 dist: trusty
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - hhvm-3.12
-  - hhvm-3.18
-  - hhvm-3.24
-  - hhvm-3.27
   - nightly
 
 matrix:
@@ -21,10 +13,6 @@ matrix:
   allow_failures:
     - php: nightly
   include:
-    - php: 5.6
-      env: DBASE=yes
-    - php: 7.0
-      env: DBASE=yes
     - php: 7.1
       env: DBASE=yes
     - php: 7.2
@@ -34,7 +22,6 @@ matrix:
 
 install:
   - if [ "$DBASE" = "yes" ] ; then ./ci/install-dbase ; fi
-  - if [ $(php -r "echo PHP_MAJOR_VERSION;") -lt 7 ] ; then sed -i '/sami/D' composer.json ; fi
   - composer install
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Drop support for PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM
+
 ## [2.1] - 2017-05-15
 
 * Documentation improvements.

--- a/ci/install-dbase
+++ b/ci/install-dbase
@@ -4,12 +4,4 @@ set -x
 set -e
 
 pecl channel-update pecl.php.net
-
-case "$TRAVIS_PHP_VERSION" in
-    5.*)
-        pecl install dbase
-        ;;
-    *)
-        pecl install dbase-7.0.0beta1
-        ;;
-esac
+pecl install dbase-7.0.0beta1

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "source": "https://github.com/phpmyadmin/shapefile"
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": "^7.1"
     },
     "suggest": {
         "ext-dbase": "For dbf files parsing"
@@ -24,7 +24,7 @@
     "require-dev": {
         "sami/sami": "^4.0",
         "phpunit/php-code-coverage": "*",
-        "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5"
+        "phpunit/phpunit": "^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <logging>
         <log type="coverage-clover" target="coverage.xml" />
     </logging>


### PR DESCRIPTION
Drop support for PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM.

Since phpMyAdmin requires PHP 7.1, it makes sense to require PHP 7.1 for shapefile as well.