### PR TITLE
Fix loadFromFile params

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: src/ShapeFile.php
 
 		-
-			message: "#^Parameter \\#2 \\$shpFile of method PhpMyAdmin\\\\ShapeFile\\\\ShapeRecord\\:\\:loadFromFile\\(\\) expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/ShapeFile.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 4
 			path: src/ShapeRecord.php

--- a/src/ShapeFile.php
+++ b/src/ShapeFile.php
@@ -457,7 +457,7 @@ class ShapeFile
         /* Need to start at offset 100 */
         while (! $this->eofSHP()) {
             $record = new ShapeRecord(-1);
-            $record->loadFromFile($this, $this->shpFile, $this->dbfFile);
+            $record->loadFromFile($this, $this->dbfFile);
             if ($record->lastError !== '') {
                 $this->setError($record->lastError);
 


### PR DESCRIPTION
This has confused me in the previous PR. If we are not using `$shpFile` then why is the method pretending to need it? I removed it and made the `$dbfFile` a param instead of property. At least now it's clear how it's used and why. 