### PR TITLE
Fix #29 - Turn ShapeType into an enum

### DIFF
--- a/examples/create_shapefile.php
+++ b/examples/create_shapefile.php
@@ -29,26 +29,26 @@ use PhpMyAdmin\ShapeFile\ShapeType;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$shp = new ShapeFile(ShapeType::POINT, [
+$shp = new ShapeFile(ShapeType::Point, [
     'xmin' => 464079.002268,
     'ymin' => 2120153.74792,
     'xmax' => 505213.52849,
     'ymax' => 2163205.70036,
 ]);
 
-$record0 = new ShapeRecord(ShapeType::POINT);
+$record0 = new ShapeRecord(ShapeType::Point);
 $record0->addPoint([
     'x' => 482131.764567,
     'y' => 2143634.39608,
 ]);
 
-$record1 = new ShapeRecord(ShapeType::POINT);
+$record1 = new ShapeRecord(ShapeType::Point);
 $record1->addPoint([
     'x' => 472131.764567,
     'y' => 2143634.39608,
 ]);
 
-$record2 = new ShapeRecord(ShapeType::POINT);
+$record2 = new ShapeRecord(ShapeType::Point);
 $record2->addPoint([
     'x' => 492131.764567,
     'y' => 2143634.39608,

--- a/examples/read.php
+++ b/examples/read.php
@@ -34,7 +34,7 @@ use PhpMyAdmin\ShapeFile\ShapeType;
 // phpcs:ignore Squiz.Functions.GlobalFunction.Found
 function display_file(string $filename): void
 {
-    $shp = new ShapeFile(ShapeType::POINT);
+    $shp = new ShapeFile(ShapeType::Point);
     $shp->loadFromFile($filename);
 
     $i = 1;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,7 +127,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 17
+			count: 18
 			path: tests/ShapeFileTest.php
 
 		-
@@ -159,4 +159,3 @@ parameters:
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 1
 			path: tests/UtilTest.php
-

--- a/src/ShapeType.php
+++ b/src/ShapeType.php
@@ -4,71 +4,74 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\ShapeFile;
 
-final class ShapeType
+enum ShapeType: int
 {
-    public const NULL = 0;
+    case Null = 0;
 
-    public const POINT = 1;
+    case Point = 1;
 
-    public const POLY_LINE = 3;
+    case PolyLine = 3;
 
-    public const POLYGON = 5;
+    case Polygon = 5;
 
-    public const MULTI_POINT = 8;
+    case MultiPoint = 8;
 
-    public const POINT_Z = 11;
+    case PointZ = 11;
 
-    public const POLY_LINE_Z = 13;
+    case PolyLineZ = 13;
 
-    public const POLYGON_Z = 15;
+    case PolygonZ = 15;
 
-    public const MULTI_POINT_Z = 18;
+    case MultiPointZ = 18;
 
-    public const POINT_M = 21;
+    case PointM = 21;
 
-    public const POLY_LINE_M = 23;
+    case PolyLineM = 23;
 
-    public const POLYGON_M = 25;
+    case PolygonM = 25;
 
-    public const MULTI_POINT_M = 28;
+    case MultiPointM = 28;
 
-    public const MULTI_PATCH = 31;
+    case MultiPatch = 31;
+
+    case Unknown = -1;
 
     /** Shape types with a Z coordinate. */
-    public const TYPES_WITH_Z = [self::POINT_Z, self::POLY_LINE_Z, self::POLYGON_Z, self::MULTI_POINT_Z];
+    public const TYPES_WITH_Z = [self::PointZ, self::PolyLineZ, self::PolygonZ, self::MultiPointZ];
 
     /** Shape types with a measure field. */
     public const MEASURED_TYPES = [
-        self::POINT_Z,
-        self::POLY_LINE_Z,
-        self::POLYGON_Z,
-        self::MULTI_POINT_Z,
-        self::POINT_M,
-        self::POLY_LINE_M,
-        self::POLYGON_M,
-        self::MULTI_POINT_M,
+        self::PointZ,
+        self::PolyLineZ,
+        self::PolygonZ,
+        self::MultiPointZ,
+        self::PointM,
+        self::PolyLineM,
+        self::PolygonM,
+        self::MultiPointM,
     ];
 
     public const NAMES = [
-        self::NULL => 'Null Shape',
-        self::POINT => 'Point',
-        self::POLY_LINE => 'PolyLine',
-        self::POLYGON => 'Polygon',
-        self::MULTI_POINT => 'MultiPoint',
-        self::POINT_Z => 'PointZ',
-        self::POLY_LINE_Z => 'PolyLineZ',
-        self::POLYGON_Z => 'PolygonZ',
-        self::MULTI_POINT_Z => 'MultiPointZ',
-        self::POINT_M => 'PointM',
-        self::POLY_LINE_M => 'PolyLineM',
-        self::POLYGON_M => 'PolygonM',
-        self::MULTI_POINT_M => 'MultiPointM',
-        self::MULTI_PATCH => 'MultiPatch',
+        self::Unknown->value => 'Unknown Shape',
+        self::Null->value => 'Null Shape',
+        self::Point->value => 'Point',
+        self::PolyLine->value => 'PolyLine',
+        self::Polygon->value => 'Polygon',
+        self::MultiPoint->value => 'MultiPoint',
+        self::PointZ->value => 'PointZ',
+        self::PolyLineZ->value => 'PolyLineZ',
+        self::PolygonZ->value => 'PolygonZ',
+        self::MultiPointZ->value => 'MultiPointZ',
+        self::PointM->value => 'PointM',
+        self::PolyLineM->value => 'PolyLineM',
+        self::PolygonM->value => 'PolygonM',
+        self::MultiPointM->value => 'MultiPointM',
+        self::MultiPatch->value => 'MultiPatch',
     ];
 
     /** @psalm-return non-empty-string */
-    public static function name(int $shapeType): string
+    public static function name(ShapeType $shapeType): string
     {
-        return self::NAMES[$shapeType] ?? 'Shape ' . $shapeType;
+        return self::NAMES[$shapeType->value];
     }
 }

--- a/tests/ShapeFileTest.php
+++ b/tests/ShapeFileTest.php
@@ -45,7 +45,7 @@ class ShapeFileTest extends TestCase
      */
     public function testLoad(string $filename, int $records, int|null $parts): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile($filename);
         $this->assertEquals('', $shp->lastError);
         $this->assertEquals($records, count($shp->records));
@@ -106,7 +106,7 @@ class ShapeFileTest extends TestCase
      */
     public function testLoadError(string $filename): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile($filename);
         $this->assertNotEquals('', $shp->lastError);
     }
@@ -116,7 +116,7 @@ class ShapeFileTest extends TestCase
      */
     public function testLoadEmptyFilename(): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('');
         if (ShapeFile::supportsDbase()) {
             $this->assertEquals('It wasn\'t possible to find the DBase file ""', $shp->lastError);
@@ -132,7 +132,7 @@ class ShapeFileTest extends TestCase
      */
     public function testGetDBFHeader(): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $this->assertNull($shp->getDBFHeader());
     }
 
@@ -162,18 +162,18 @@ class ShapeFileTest extends TestCase
      */
     private function createTestData(): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
 
-        $record0 = new ShapeRecord(ShapeType::POINT);
+        $record0 = new ShapeRecord(ShapeType::Point);
         $record0->addPoint(['x' => 482131.764567, 'y' => 2143634.39608]);
 
-        $record1 = new ShapeRecord(ShapeType::POINT_Z);
+        $record1 = new ShapeRecord(ShapeType::PointZ);
         $record1->addPoint(['x' => 472131.764567, 'y' => 2143634.39608, 'z' => 220, 'm' => 120]);
 
-        $record2 = new ShapeRecord(ShapeType::POINT_M);
+        $record2 = new ShapeRecord(ShapeType::PointM);
         $record2->addPoint(['x' => 492131.764567, 'y' => 2143634.39608, 'z' => 150, 'm' => 80]);
 
-        $record3 = new ShapeRecord(ShapeType::POLY_LINE);
+        $record3 = new ShapeRecord(ShapeType::PolyLine);
         $record3->addPoint(['x' => 482131.764567, 'y' => 2143634.39608], 0);
         $record3->addPoint(['x' => 482132.764567, 'y' => 2143635.39608], 0);
         $record3->addPoint(['x' => 482131.764567, 'y' => 2143635.39608], 1);
@@ -227,7 +227,7 @@ class ShapeFileTest extends TestCase
 
         $this->createTestData();
 
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('./data/test_shape.*');
         $this->assertEquals(4, count($shp->records));
     }
@@ -243,13 +243,13 @@ class ShapeFileTest extends TestCase
 
         $this->createTestData();
 
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('./data/test_shape.*');
         $shp->deleteRecord(1);
         $shp->saveToFile();
         $this->assertEquals(3, count($shp->records));
 
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('./data/test_shape.*');
         $this->assertEquals(3, count($shp->records));
     }
@@ -265,10 +265,10 @@ class ShapeFileTest extends TestCase
 
         $this->createTestData();
 
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('./data/test_shape.*');
 
-        $record0 = new ShapeRecord(ShapeType::POINT);
+        $record0 = new ShapeRecord(ShapeType::Point);
         $record0->addPoint(['x' => 482131.764567, 'y' => 2143634.39608]);
 
         $shp->addRecord($record0);
@@ -278,7 +278,7 @@ class ShapeFileTest extends TestCase
         $shp->saveToFile();
         $this->assertEquals(5, count($shp->records));
 
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->loadFromFile('./data/test_shape.*');
         $this->assertEquals(5, count($shp->records));
     }
@@ -288,7 +288,7 @@ class ShapeFileTest extends TestCase
      */
     public function testSaveNoDBF(): void
     {
-        $shp = new ShapeFile(ShapeType::POINT);
+        $shp = new ShapeFile(ShapeType::Point);
         $shp->saveToFile('./data/test_nodbf.*');
 
         $this->assertFileDoesNotExist('./data/test_nodbf.dbf');
@@ -299,12 +299,14 @@ class ShapeFileTest extends TestCase
      */
     public function testShapeName(): void
     {
-        $obj = new ShapeRecord(ShapeType::POINT);
+        $obj = new ShapeRecord(ShapeType::Point);
         $this->assertEquals('Point', $obj->getShapeName());
-        $obj = new ShapeFile(ShapeType::POINT);
+        $obj = new ShapeFile(ShapeType::Point);
         $this->assertEquals('Point', $obj->getShapeName());
-        $obj = new ShapeRecord(-1);
-        $this->assertEquals('Shape -1', $obj->getShapeName());
+        $obj = new ShapeRecord(ShapeType::Null);
+        $this->assertEquals('Null Shape', $obj->getShapeName());
+        $obj = new ShapeRecord(ShapeType::Unknown);
+        $this->assertEquals('Unknown Shape', $obj->getShapeName());
     }
 
     /**
@@ -314,9 +316,9 @@ class ShapeFileTest extends TestCase
      *
      * @dataProvider shapesProvider
      */
-    public function testShapeSaveLoad(int $shapeType, array $points): void
+    public function testShapeSaveLoad(ShapeType $shapeType, array $points): void
     {
-        $filename = './data/test_shape-' . $shapeType . '.*';
+        $filename = './data/test_shape-' . $shapeType->value . '.*';
         $shp = new ShapeFile($shapeType);
         $shp->setDBFHeader([['ID', 'N', 19, 0], ['DESC', 'C', 14, 0]]);
 
@@ -354,7 +356,7 @@ class ShapeFileTest extends TestCase
     /**
      * Data provider for save/load testing.
      *
-     * @psalm-return list<array{int, list<array{mixed[], int}>}>
+     * @psalm-return list<array{ShapeType, list<array{mixed[], int}>}>
      */
     public static function shapesProvider(): array
     {
@@ -383,24 +385,24 @@ class ShapeFileTest extends TestCase
         ];
 
         return [
-            [ShapeType::POINT, $pointsForPointType],
-            [ShapeType::POLY_LINE, $pointsForPolyLineType],
-            [ShapeType::POLYGON, $pointsForPolygonType],
-            [ShapeType::MULTI_POINT, $pointsForMultiPointType],
-            [ShapeType::POINT_Z, $pointsForPointType],
-            [ShapeType::POLY_LINE_Z, $pointsForPolyLineType],
-            [ShapeType::POLYGON_Z, $pointsForPolygonType],
-            [ShapeType::MULTI_POINT_Z, $pointsForMultiPointType],
-            [ShapeType::POINT_M, $pointsForPointType],
-            [ShapeType::POLY_LINE_M, $pointsForPolyLineType],
-            [ShapeType::POLYGON_M, $pointsForPolygonType],
-            [ShapeType::MULTI_POINT_M, $pointsForMultiPointType],
+            [ShapeType::Point, $pointsForPointType],
+            [ShapeType::PolyLine, $pointsForPolyLineType],
+            [ShapeType::Polygon, $pointsForPolygonType],
+            [ShapeType::MultiPoint, $pointsForMultiPointType],
+            [ShapeType::PointZ, $pointsForPointType],
+            [ShapeType::PolyLineZ, $pointsForPolyLineType],
+            [ShapeType::PolygonZ, $pointsForPolygonType],
+            [ShapeType::MultiPointZ, $pointsForMultiPointType],
+            [ShapeType::PointM, $pointsForPointType],
+            [ShapeType::PolyLineM, $pointsForPolyLineType],
+            [ShapeType::PolygonM, $pointsForPolygonType],
+            [ShapeType::MultiPointM, $pointsForMultiPointType],
         ];
     }
 
     public function testSearch(): void
     {
-        $shp = new ShapeFile(ShapeType::NULL);
+        $shp = new ShapeFile(ShapeType::Null);
         $shp->loadFromFile('data/capitals.*');
         /* Nonexisting entry or no dbase support */
         $this->assertEquals(


### PR DESCRIPTION
Hi!

Thought I'd give a go at #29 .

In various places `shapeType` was set to `-1` as default value. I replaced it with `ShapeType::NULL` and would like feed back on that.

Thanks for reviewing!

- Fixes #29

- Related to https://github.com/phpmyadmin/shapefile/pull/26